### PR TITLE
Fix numbering of local setup documentation

### DIFF
--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -53,7 +53,7 @@ frontend:
     production: ~
 ```
 
-### 5. Run it locally
+### 4. Run it locally
 The Gardener Dashboard [`backend`](../../backend) server requires a kubeconfig for the Garden cluster. You can set it e.g. by using the `KUBECONFIG` environment variable.
 
 If you want to run the Garden cluster locally, follow the [getting started locally](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md) documentation.
@@ -75,7 +75,7 @@ yarn serve
 
 You can now access the UI on http://localhost:8080/
 
-### 6. Login to the dashboard
+### 5. Login to the dashboard
 To login to the dashboard you can either configure `oidc`, or alternatively login using a token:
 
 To login using a token, first create a service account.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix numbering of local setup documentation.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user

```
